### PR TITLE
feat: add GET /api/v1/books/{book_id} endpoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,5 @@ cython_debug/
 
 aws/
 awscliv2.zip
+*.sh
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,34 @@
+# Stage 1: Python/FastAPI
+FROM python:3.9-slim as fastapi
+
+WORKDIR /fastapi-book-project
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . .
+
+# Stage 2: Nginx
+FROM nginx:alpine
+
+# Remove default nginx config
+RUN rm /etc/nginx/conf.d/default.conf
+
+# Copy custom nginx config
+COPY docker/nginx/nginx.conf /etc/nginx/nginx.conf
+
+# Copy FastAPI app from previous stage
+COPY --from=fastapi /fastapi-book-project /fastapi-book-project
+
+# Install Python and dependencies in Nginx image
+RUN apk add --no-cache python3 py3-pip \
+    && pip3 install --break-system-packages --no-cache-dir -r /fastapi-book-project/requirements.txt
+
+# Expose port 80
+EXPOSE 80
+
+# Start Nginx and FastAPI
+COPY docker/start.sh /start.sh
+RUN chmod +x /start.sh
+
+CMD ["/start.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,31 @@
+version: '3.8'
+
+services:
+  api:
+    build: .
+    container_name: fastapi_app
+    volumes:
+      - .:/app
+    ports:
+      - "8000:8000"
+    restart: always
+    command: uvicorn main:app --host 0.0.0.0 --port 8000
+    networks:
+      - app_network
+
+  nginx:
+    image: nginx:alpine
+    container_name: nginx_proxy
+    restart: always
+    ports:
+      - "80:80"
+    volumes:
+      - ./docker/nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    depends_on:
+      - api
+    networks:
+      - app_network
+
+networks:
+  app_network:
+    driver: bridge

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -1,0 +1,34 @@
+events {
+    worker_connections 1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    upstream fastapi_app {
+        server localhost:8000;
+    }
+
+    server {
+        listen 80;
+        server_name localhost;
+
+        location / {
+            proxy_pass http://fastapi_app;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+
+        location /healthcheck {
+            access_log off;
+            add_header Content-Type text/plain;
+            return 200 'healthy';
+        }
+    }
+}

--- a/render.yaml
+++ b/render.yaml
@@ -1,0 +1,12 @@
+services:
+  - type: web
+    name: fastapi-book-project
+    env: docker
+    region: oregon
+    plan: free
+    dockerImage: emminex/fastapi-book-project:latest
+    envVars:
+      - key: PORT
+        value: 80
+    healthCheckPath: /healthcheck
+    autoDeploy: true


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Configured Nginx reverse proxy for FastAPI.  

## Related Task  
[HNG12 Stage 2 Task](#task-description-link)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  

## Notes  
- Invited hng12-devbot as a collaborator. 