### PR TITLE
fix: fixed some docker and nginx issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,34 +1,31 @@
-# Stage 1: Python/FastAPI
-FROM python:3.9-slim as fastapi
+FROM python:3.9-slim
+
+# Install nginx
+RUN apt-get update && \
+    apt-get install -y nginx && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
 WORKDIR /fastapi-book-project
 
+# Copy requirements first to leverage Docker cache
 COPY requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN pip install --break-system-packages --no-cache-dir -r requirements.txt
 
+# Copy all project files
 COPY . .
 
-# Stage 2: Nginx
-FROM nginx:alpine
+# Remove default nginx configuration
+RUN rm /etc/nginx/nginx.conf
 
-# Remove default nginx config
-RUN rm /etc/nginx/conf.d/default.conf
-
-# Copy custom nginx config
+# Copy nginx configuration
 COPY docker/nginx/nginx.conf /etc/nginx/nginx.conf
 
-# Copy FastAPI app from previous stage
-COPY --from=fastapi /fastapi-book-project /fastapi-book-project
-
-# Install Python and dependencies in Nginx image
-RUN apk add --no-cache python3 py3-pip \
-    && pip3 install --break-system-packages --no-cache-dir -r /fastapi-book-project/requirements.txt
+# Create start script with proper format
+RUN echo '#!/bin/sh\n\ncd /fastapi-book-project && uvicorn main:app --host 0.0.0.0 --port 8000 --workers 4 &\n\nsleep 5\n\nnginx -t && nginx -g "daemon off;"\n' > /start.sh && \
+    chmod +x /start.sh
 
 # Expose port 80
 EXPOSE 80
-
-# Start Nginx and FastAPI
-COPY docker/start.sh /start.sh
-RUN chmod +x /start.sh
 
 CMD ["/start.sh"]

--- a/docker/nginx/nginx.conf
+++ b/docker/nginx/nginx.conf
@@ -5,7 +5,7 @@ events {
 http {
     include       /etc/nginx/mime.types;
     default_type  application/octet-stream;
-
+    
     upstream fastapi_app {
         server localhost:8000;
     }
@@ -13,22 +13,21 @@ http {
     server {
         listen 80;
         server_name localhost;
-
+		more_set_headers "Server: nginx";
         location / {
             proxy_pass http://fastapi_app;
             proxy_set_header Host $host;
             proxy_set_header X-Real-IP $remote_addr;
             proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
             proxy_set_header X-Forwarded-Proto $scheme;
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
+            proxy_set_header Server "nginx";
         }
 
         location /healthcheck {
             access_log off;
-            add_header Content-Type text/plain;
-            return 200 'healthy';
+            add_header Content-Type application/json;
+            add_header Server "nginx" always;
+            return 200 '{"status":"healthy","timestamp":"2025-02-11 08:52:44","server":"nginx"}';
         }
     }
 }


### PR DESCRIPTION
## Description  
- Added GET `/api/v1/books/{book_id}` endpoint to retrieve book details.  
- Configured Nginx reverse proxy for FastAPI.  

## Related Task  
[HNG12 Stage 2 Task](#task-description-link)  

## Testing  
- Ran `pytest` locally (all tests passed).  
- Tested invalid IDs (e.g., `/books/999`) to confirm 404 response.  